### PR TITLE
fix: ahash does more work then required

### DIFF
--- a/ahash/ahash.lua
+++ b/ahash/ahash.lua
@@ -1,14 +1,6 @@
-local M = {}
-
-local hashes = {}
-local hash_metatable = {
-	__index = function(hashes_table, hash_key)
-		if hashes[hash_key] == nil then
-			rawset(hashes, hash_key, hash(hash_key))
-		end
-		return hashes[hash_key]
-	end
-}
-setmetatable(M, hash_metatable)
-
-return M
+return setmetatable({}, {
+    __index = function(t, k)
+        rawset(t, k, hash(k))
+        return t[k]
+    end,
+})


### PR DESCRIPTION
Even though ahash module caches hash() values, it is on every key lookup still checking for its existence executing `__index` function. Removing intermediate table fixes this.